### PR TITLE
Expose Datum.valid_angles to Python API

### DIFF
--- a/python/pylc_lib.cpp
+++ b/python/pylc_lib.cpp
@@ -142,6 +142,7 @@ PYBIND11_MODULE(pylc_lib, m) {
             .def_readwrite("hit_pow", &Datum::hit_pow)
             .def_readwrite("hit_mode", &Datum::hit_mode)
             .def_readwrite("hit_noise", &Datum::hit_noise)
+            .def_readwrite("valid_angles", &Datum::valid_angles)
             ;
 
     // Input Object

--- a/python/sim.py
+++ b/python/sim.py
@@ -122,6 +122,11 @@ class LCDevice:
         self.datum_processor = pylc_lib.DatumProcessor()
         self.datum_processor.setSensors([c_datum], [l_datum])
 
+        # Angles of each camera ray, from leftmost to righmost ray.
+        # Angles are measured in degrees, with respect to the z-axis, in sorted (increasing) order.
+        # Hence, they lie in [-fov/2, fov/2].
+        self.thetas = np.array(c_datum.valid_angles, dtype=np.float32)  # degrees
+
     def _get_transform_from_xyzrpy(self, x, y, z, roll, pitch, yaw):
         # convert roll, pitch, yaw to radians.
         roll, pitch, yaw = roll * np.pi/180., pitch * np.pi/180., yaw * np.pi/180.


### PR DESCRIPTION
So that one can directly access camera angles without having to compute them from the light curtain image.